### PR TITLE
Fixed a vulnerability in the encryption service.

### DIFF
--- a/Windows/Def/PaZword.Api/Data/IUpgradeService.cs
+++ b/Windows/Def/PaZword.Api/Data/IUpgradeService.cs
@@ -19,11 +19,11 @@ namespace PaZword.Api.Data
         /// </summary>
         /// <param name="userDataBundleFile">The file containing the user data bundle to migrate.</param>
         /// <returns>A up to date user data bundle and a value indicated if it had to be updated.</returns>
-        Task<(bool updated, UserDataBundle userDataBundle)> MigrateUserDataBundleAsync(StorageFile userDataBundleFile);
+        Task<(bool updated, UserDataBundle userDataBundle)> UpgradeUserDataBundleAsync(StorageFile userDataBundleFile);
 
         /// <summary>
         /// Migrates the application settings.
         /// </summary>
-        void MigrateSettings();
+        void UpgradeSettings();
     }
 }

--- a/Windows/Def/PaZword.Api/Security/IEncryptionProvider.cs
+++ b/Windows/Def/PaZword.Api/Security/IEncryptionProvider.cs
@@ -55,16 +55,18 @@ namespace PaZword.Api.Security
         /// Encrypts a given string using AES encryption algorithm and returns it in Base64.
         /// </summary>
         /// <param name="data">Data to be encrypted</param>
+        /// <param name="reuseGlobalIV">Defines whether the global initialization vector (IV) should be used to encrypt.</param>
         /// <returns>An encrypted string in Base64</returns>
-        string EncryptString(string data);
+        string EncryptString(string data, bool reuseGlobalIV = false);
 
         /// <summary>
         /// Encrypts a given string using AES encryption algorithm and returns it in Base64.
         /// </summary>
         /// <param name="data">Data to be encrypted</param>
         /// <param name="defaultValue">The default value to return if the <paramref name="data"/> is empty.</param>
+        /// <param name="reuseGlobalIV">Defines whether the global initialization vector (IV) should be used to encrypt.</param>
         /// <returns>An encrypted string in Base64</returns>
-        string EncryptString(string data, string defaultValue);
+        string EncryptString(string data, string defaultValue, bool reuseGlobalIV = false);
 
         /// <summary>
         /// Decrypts a string through AES encryption algorithm.

--- a/Windows/Impl/PaZword.Core/Data/DataManager.cs
+++ b/Windows/Impl/PaZword.Core/Data/DataManager.cs
@@ -188,7 +188,7 @@ namespace PaZword.Core.Data
                 byte[] byteArray = new byte[fileStream.Size];
                 reader.ReadBytes(byteArray);
 
-                string encryptedFileContent = _encryptionProvider.EncryptString(Convert.ToBase64String(byteArray));
+                string encryptedFileContent = _encryptionProvider.EncryptString(Convert.ToBase64String(byteArray), reuseGlobalIV: true);
 
                 await CoreHelper.RetryAsync(async () =>
                 {
@@ -697,7 +697,7 @@ namespace PaZword.Core.Data
 
                 // Encrypt the user data.
                 string jsonData = _serializationProvider.SerializeObject(_data);
-                string encryptedData = _encryptionProvider.EncryptString(jsonData);
+                string encryptedData = _encryptionProvider.EncryptString(jsonData, reuseGlobalIV: true);
 
                 await CoreHelper.RetryAsync(async () =>
                 {

--- a/Windows/Impl/PaZword.Core/Data/DataManager.cs
+++ b/Windows/Impl/PaZword.Core/Data/DataManager.cs
@@ -110,7 +110,7 @@ namespace PaZword.Core.Data
                 }
 
                 // Loads the user data bundle and migrate it (if needed)
-                await _upgradeService.MigrateUserDataBundleAsync(dataFile).ConfigureAwait(false);
+                await _upgradeService.UpgradeUserDataBundleAsync(dataFile).ConfigureAwait(false);
 
                 return true;
             }
@@ -138,7 +138,7 @@ namespace PaZword.Core.Data
                 }
 
                 // Loads the user data bundle and migrate it (if needed)
-                (bool updated, UserDataBundle data) = await _upgradeService.MigrateUserDataBundleAsync(dataFile).ConfigureAwait(false);
+                (bool updated, UserDataBundle data) = await _upgradeService.UpgradeUserDataBundleAsync(dataFile).ConfigureAwait(false);
 
                 _logger.LogEvent(LoadedEvent, string.Empty);
                 if (_data == null)

--- a/Windows/Impl/PaZword.Localization/Strings/fr/BankAccountData.resw
+++ b/Windows/Impl/PaZword.Localization/Strings/fr/BankAccountData.resw
@@ -127,7 +127,7 @@
     <value>Nom de la banque</value>
   </data>
   <data name="DisplayName" xml:space="preserve">
-    <value>Numéro de compte en banque</value>
+    <value>Compte en banque</value>
   </data>
   <data name="IbanNumber" xml:space="preserve">
     <value>IBAN</value>

--- a/Windows/Impl/PaZword.Localization/Strings/fr/LicenseKeyData.resw
+++ b/Windows/Impl/PaZword.Localization/Strings/fr/LicenseKeyData.resw
@@ -121,7 +121,7 @@
     <value>Nom de l'entreprise</value>
   </data>
   <data name="DisplayName" xml:space="preserve">
-    <value>Numéro de compte en banque</value>
+    <value>Licence</value>
   </data>
   <data name="LicenseKey" xml:space="preserve">
     <value>Clé de licence</value>

--- a/Windows/Impl/PaZword/Models/Data/BankAccountData.cs
+++ b/Windows/Impl/PaZword/Models/Data/BankAccountData.cs
@@ -1,16 +1,18 @@
 ﻿using Newtonsoft.Json;
+using PaZword.Api.Data;
 using PaZword.Api.Models;
 using PaZword.Core;
 using PaZword.Core.Json;
 using System;
 using System.Security;
+using System.Threading.Tasks;
 
 namespace PaZword.Models.Data
 {
     /// <summary>
     /// Represents the data associated to a bank account.
     /// </summary>
-    internal sealed class BankAccountData : AccountData
+    internal sealed class BankAccountData : AccountData, IUpgradableAccountData
     {
         [SecurityCritical]
         [JsonProperty(nameof(BankName))]
@@ -167,6 +169,27 @@ namespace PaZword.Models.Data
                 && bankAccountData._pin.IsEqualTo(_pin)
                 && bankAccountData._routingNumber.IsEqualTo(_routingNumber)
                 && bankAccountData._swiftCode.IsEqualTo(_swiftCode);
+        }
+
+        public Task UpgradeAsync(int oldVersion, int targetVersion)
+        {
+            if (oldVersion == 1)
+            {
+                // In Version 1, there was a vulnerability in the encryption engine.
+                // Let's fix it by decrypting and re-encrypting all data.
+
+#pragma warning disable CA2245 // Do not assign a property to itself.
+                AccountHolderName = AccountHolderName;
+                AccountNumber = AccountNumber;
+                BankName = BankName;
+                IbanNumber = IbanNumber;
+                Pin = Pin;
+                RoutingNumber = RoutingNumber;
+                SwiftCode = SwiftCode;
+#pragma warning restore CA2245 // Do not assign a property to itself.
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Windows/Impl/PaZword/Models/Data/CredentialData.cs
+++ b/Windows/Impl/PaZword/Models/Data/CredentialData.cs
@@ -1,16 +1,18 @@
 ﻿using Newtonsoft.Json;
+using PaZword.Api.Data;
 using PaZword.Api.Models;
 using PaZword.Core;
 using PaZword.Core.Json;
 using System;
 using System.Security;
+using System.Threading.Tasks;
 
 namespace PaZword.Models.Data
 {
     /// <summary>
     /// Represents the data associated to a login.
     /// </summary>
-    internal sealed class CredentialData : AccountData
+    internal sealed class CredentialData : AccountData, IUpgradableAccountData
     {
         [SecurityCritical]
         [JsonProperty(nameof(Username))]
@@ -133,6 +135,25 @@ namespace PaZword.Models.Data
                 && credentialData._password.IsEqualTo(_password)
                 && credentialData._securityQuestion.IsEqualTo(_securityQuestion)
                 && credentialData._securityQuestionAnswer.IsEqualTo(_securityQuestionAnswer);
+        }
+
+        public Task UpgradeAsync(int oldVersion, int targetVersion)
+        {
+            if (oldVersion == 1)
+            {
+                // In Version 1, there was a vulnerability in the encryption engine.
+                // Let's fix it by decrypting and re-encrypting all data.
+
+#pragma warning disable CA2245 // Do not assign a property to itself.
+                Username = Username;
+                EmailAddress = EmailAddress;
+                Password = Password;
+                SecurityQuestion = SecurityQuestion;
+                SecurityQuestionAnswer = SecurityQuestionAnswer;
+#pragma warning restore CA2245 // Do not assign a property to itself.
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Windows/Impl/PaZword/Models/Data/FileData.cs
+++ b/Windows/Impl/PaZword/Models/Data/FileData.cs
@@ -1,16 +1,18 @@
 ﻿using Newtonsoft.Json;
+using PaZword.Api.Data;
 using PaZword.Api.Models;
 using PaZword.Core;
 using PaZword.Core.Json;
 using System;
 using System.Security;
+using System.Threading.Tasks;
 
 namespace PaZword.Models.Data
 {
     /// <summary>
     /// Represents the data for a file.
     /// </summary>
-    internal sealed class FileData : AccountData
+    internal sealed class FileData : AccountData, IUpgradableAccountData
     {
         [SecurityCritical]
         [JsonProperty(nameof(FileName))]
@@ -106,6 +108,22 @@ namespace PaZword.Models.Data
                 && fileData._fileName.IsEqualTo(_fileName)
                 && fileData._fileExtension.IsEqualTo(_fileExtension)
                 && string.Equals(fileData._base64Thumbnail, _base64Thumbnail, StringComparison.Ordinal);
+        }
+
+        public Task UpgradeAsync(int oldVersion, int targetVersion)
+        {
+            if (oldVersion == 1)
+            {
+                // In Version 1, there was a vulnerability in the encryption engine.
+                // Let's fix it by decrypting and re-encrypting all data.
+
+#pragma warning disable CA2245 // Do not assign a property to itself.
+                FileName = FileName;
+                FileExtension = FileExtension;
+#pragma warning restore CA2245 // Do not assign a property to itself.
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Windows/Impl/PaZword/Models/Data/LicenseKeyData.cs
+++ b/Windows/Impl/PaZword/Models/Data/LicenseKeyData.cs
@@ -1,16 +1,18 @@
 ﻿using Newtonsoft.Json;
+using PaZword.Api.Data;
 using PaZword.Api.Models;
 using PaZword.Core;
 using PaZword.Core.Json;
 using System;
 using System.Security;
+using System.Threading.Tasks;
 
 namespace PaZword.Models.Data
 {
     /// <summary>
     /// Represents the data associated to a software license.
     /// </summary>
-    internal sealed class LicenseKeyData : AccountData
+    internal sealed class LicenseKeyData : AccountData, IUpgradableAccountData
     {
         [SecurityCritical]
         [JsonProperty(nameof(LicenseTo))]
@@ -116,6 +118,24 @@ namespace PaZword.Models.Data
                 && licenseKeyData._linkedEmailAddress.IsEqualTo(_linkedEmailAddress)
                 && licenseKeyData._company.IsEqualTo(_company)
                 && licenseKeyData._licenseKey.IsEqualTo(_licenseKey);
+        }
+
+        public Task UpgradeAsync(int oldVersion, int targetVersion)
+        {
+            if (oldVersion == 1)
+            {
+                // In Version 1, there was a vulnerability in the encryption engine.
+                // Let's fix it by decrypting and re-encrypting all data.
+
+#pragma warning disable CA2245 // Do not assign a property to itself.
+                LicenseTo = LicenseTo;
+                LinkedEmailAddress = LinkedEmailAddress;
+                Company = Company;
+                LicenseKey= LicenseKey;
+#pragma warning restore CA2245 // Do not assign a property to itself.
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Windows/Impl/PaZword/Models/Data/OtherData.cs
+++ b/Windows/Impl/PaZword/Models/Data/OtherData.cs
@@ -1,16 +1,18 @@
 ﻿using Newtonsoft.Json;
+using PaZword.Api.Data;
 using PaZword.Api.Models;
 using PaZword.Core;
 using PaZword.Core.Json;
 using System;
 using System.Security;
+using System.Threading.Tasks;
 
 namespace PaZword.Models.Data
 {
     /// <summary>
     /// Represents the data for a random type of data.
     /// </summary>
-    internal sealed class OtherData : AccountData
+    internal sealed class OtherData : AccountData, IUpgradableAccountData
     {
         [SecurityCritical]
         [JsonProperty(nameof(Name))]
@@ -82,6 +84,22 @@ namespace PaZword.Models.Data
                 && otherData.Id == Id
                 && otherData._name.IsEqualTo(_name)
                 && otherData._value.IsEqualTo(_value);
+        }
+
+        public Task UpgradeAsync(int oldVersion, int targetVersion)
+        {
+            if (oldVersion == 1)
+            {
+                // In Version 1, there was a vulnerability in the encryption engine.
+                // Let's fix it by decrypting and re-encrypting all data.
+
+#pragma warning disable CA2245 // Do not assign a property to itself.
+                Name = Name;
+                Value = Value;
+#pragma warning restore CA2245 // Do not assign a property to itself.
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Windows/Impl/PaZword/Models/Data/PaymentCardData.cs
+++ b/Windows/Impl/PaZword/Models/Data/PaymentCardData.cs
@@ -1,16 +1,18 @@
 ﻿using Newtonsoft.Json;
+using PaZword.Api.Data;
 using PaZword.Api.Models;
 using PaZword.Core;
 using PaZword.Core.Json;
 using System;
 using System.Security;
+using System.Threading.Tasks;
 
 namespace PaZword.Models.Data
 {
     /// <summary>
     /// Represents the data associated to a payment card.
     /// </summary>
-    internal sealed class PaymentCardData : AccountData
+    internal sealed class PaymentCardData : AccountData, IUpgradableAccountData
     {
         [SecurityCritical]
         [JsonProperty(nameof(BankName))]
@@ -129,6 +131,24 @@ namespace PaZword.Models.Data
                 && paymentCardData._cardHolderName.IsEqualTo(_cardHolderName)
                 && paymentCardData._cardNumber.IsEqualTo(_cardNumber)
                 && paymentCardData._cardCryptogram.IsEqualTo(_cardCryptogram);
+        }
+
+        public Task UpgradeAsync(int oldVersion, int targetVersion)
+        {
+            if (oldVersion == 1)
+            {
+                // In Version 1, there was a vulnerability in the encryption engine.
+                // Let's fix it by decrypting and re-encrypting all data.
+
+#pragma warning disable CA2245 // Do not assign a property to itself.
+                BankName = BankName;
+                CardHolderName = CardHolderName;
+                CardNumber = CardNumber;
+                CardCryptogram = CardCryptogram;
+#pragma warning restore CA2245 // Do not assign a property to itself.
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Windows/Impl/PaZword/Models/Data/WiFiCredentialData.cs
+++ b/Windows/Impl/PaZword/Models/Data/WiFiCredentialData.cs
@@ -1,16 +1,18 @@
 ﻿using Newtonsoft.Json;
+using PaZword.Api.Data;
 using PaZword.Api.Models;
 using PaZword.Core;
 using PaZword.Core.Json;
 using System;
 using System.Security;
+using System.Threading.Tasks;
 
 namespace PaZword.Models.Data
 {
     /// <summary>
     /// Represents the data associated to a Wi-Fi password.
     /// </summary>
-    internal sealed class WiFiCredentialData : AccountData
+    internal sealed class WiFiCredentialData : AccountData, IUpgradableAccountData
     {
         [SecurityCritical]
         [JsonProperty(nameof(Ssid))]
@@ -82,6 +84,22 @@ namespace PaZword.Models.Data
                 && wifiCredentialData.Id == Id
                 && wifiCredentialData._ssid.IsEqualTo(_ssid)
                 && wifiCredentialData._password.IsEqualTo(_password);
+        }
+
+        public Task UpgradeAsync(int oldVersion, int targetVersion)
+        {
+            if (oldVersion == 1)
+            {
+                // In Version 1, there was a vulnerability in the encryption engine.
+                // Let's fix it by decrypting and re-encrypting all data.
+
+#pragma warning disable CA2245 // Do not assign a property to itself.
+                Ssid = Ssid;
+                Password = Password;
+#pragma warning restore CA2245 // Do not assign a property to itself.
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Windows/Test/PaZword.Tests/Integration/FirstStartExperienceTests.cs
+++ b/Windows/Test/PaZword.Tests/Integration/FirstStartExperienceTests.cs
@@ -94,7 +94,7 @@ namespace PaZword.Tests.Integration
             viewModel.RegisterToRemoteStorageServiceCommand.WaitRunToCompletion();
 
             Assert.AreEqual(FirstStartExperiencePageViewModel.StepWindowsHello, viewModel.CurrentStepIndex);
-            Assert.IsTrue(viewModel.UseWindowsHello);
+            Assert.IsFalse(viewModel.UseWindowsHello);
 
             viewModel.BackCommand.Execute(null);
             Assert.AreEqual(FirstStartExperiencePageViewModel.StepRegisterToCloudService, viewModel.CurrentStepIndex);

--- a/Windows/Test/PaZword.Tests/Security/EncryptionProvidertests.cs
+++ b/Windows/Test/PaZword.Tests/Security/EncryptionProvidertests.cs
@@ -18,8 +18,36 @@ namespace PaZword.Tests.Security
 
             encryptionProvider.SetSecretKeys(encryptionKeys);
 
-            var encryptedString = encryptionProvider.EncryptString(stringToEncrypt);
+            var encryptedString = encryptionProvider.EncryptString(stringToEncrypt, reuseGlobalIV: true);
+            var encryptedString2 = encryptionProvider.EncryptString(stringToEncrypt, reuseGlobalIV: true);
 
+            Assert.AreEqual(encryptedString, encryptedString2);
+            Assert.AreNotEqual(stringToEncrypt, encryptedString);
+
+            encryptionProvider = new EncryptionProvider();
+            encryptionKeys = encryptionProvider.DecodeSecretKeysFromBase64(recoveryKey);
+            encryptionProvider.SetSecretKeys(encryptionKeys);
+
+            var decryptedString = encryptionProvider.DecryptString(encryptedString);
+
+            Assert.AreEqual(stringToEncrypt, decryptedString);
+        }
+
+        [TestMethod]
+        public void EncryptionProviderUniqueIVTest()
+        {
+            var stringToEncrypt = "Hello World";
+
+            IEncryptionProvider encryptionProvider = new EncryptionProvider();
+            var encryptionKeys = encryptionProvider.GenerateSecretKeys();
+            var recoveryKey = encryptionProvider.EncodeSecretKeysToBase64(encryptionKeys);
+
+            encryptionProvider.SetSecretKeys(encryptionKeys);
+
+            var encryptedString = encryptionProvider.EncryptString(stringToEncrypt);
+            var encryptedString2 = encryptionProvider.EncryptString(stringToEncrypt);
+
+            Assert.AreNotEqual(encryptedString, encryptedString2);
             Assert.AreNotEqual(stringToEncrypt, encryptedString);
 
             encryptionProvider = new EncryptionProvider();


### PR DESCRIPTION
Fixed a vulnerability in the encryption service where the initialization vector (IV) was reused for each account data's data.

The fix requires an upgrade of the user data bundle to be sure everything gets re-encrypted to fix the vulnerability.
Retro-compatibility is supported.